### PR TITLE
chore: standardize .gitignore across repos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -282,3 +282,7 @@ $RECYCLE.BIN/
 
 # Windows shortcuts
 *.lnk
+
+# Claude Code local settings
+CLAUDE.local.md
+.claude/


### PR DESCRIPTION
Standardize .gitignore to match other VS extension repos.