### PR TITLE
chore(workflow): use shared workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,39 +4,21 @@ on:
   workflow_dispatch:
   pull_request:
     types: [opened, reopened]
+    paths:
+      - 'src/**'
+      - '*.slnx'
+      - '.github/workflows/build.yml'
   push:
     branches:
       - main
+    paths:
+      - 'src/**'
+      - '*.slnx'
+      - '.github/workflows/build.yml'
 
 jobs:
   build:
-    runs-on: windows-latest
-
-    steps:
-    - uses: actions/checkout@v4
-
-    - name: 1. Generate Version
-      id: version
-      run: |
-        $year = (Get-Date).Year
-        $month = (Get-Date).Month
-        $day = (Get-Date).Day
-        $version = "$year.$month.$day.${{ github.run_number }}"
-        echo "version=$version" >> $env:GITHUB_OUTPUT
-      shell: pwsh
-
-    - name: 2. Build Project
-      run: dotnet build src/CodingWithCalvin.SuperClean/CodingWithCalvin.SuperClean.csproj -c Release -p:SetVsixVersion=${{ steps.version.outputs.version }}
-
-    - name: 3. Create Information File
-      uses: jsdaniell/create-json@v1.2.3
-      with:
-        name: 'src/CodingWithCalvin.SuperClean/bin/Release/CodingWithCalvin.SuperClean.info'
-        json: '{"sha":"${{ github.sha }}", "version":"${{ steps.version.outputs.version }}"}'
-
-    - name: 4. Upload Artifact
-      uses: actions/upload-artifact@v4
-      with:
-        path: |
-          src/CodingWithCalvin.SuperClean/bin/Release/CodingWithCalvin.SuperClean.info
-          src/CodingWithCalvin.SuperClean/bin/Release/CodingWithCalvin.SuperClean.vsix
+    uses: CodingWithCalvin/.github/.github/workflows/vsix-build.yml@main
+    with:
+      extension-name: SuperClean
+    secrets: inherit

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,46 +3,16 @@ name: Publish to VS Marketplace
 on:
   workflow_dispatch:
 
+permissions:
+  contents: write
+  actions: read
+
 jobs:
-  changelog:
-    name: Generate Changelog
-    uses: CodingWithCalvin/.github/.github/workflows/generate-changelog.yml@main
-
   publish:
-    needs: changelog
-    runs-on: windows-latest
-    permissions:
-      contents: write
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: 1. Download artifact
-        id: download-artifact
-        uses: dawidd6/action-download-artifact@v6
-        with:
-          workflow: build.yml
-          workflow_conclusion: success
-
-      - name: 2. Parse Artifact Manifest
-        id: artifact_manifest
-        uses: ActionsTools/read-json-action@main
-        with:
-          file_path: ./artifact/CodingWithCalvin.SuperClean.info
-
-      - name: 3. Create Tag & Release
-        uses: ncipollo/release-action@v1.14.0
-        with:
-          artifacts: ./artifact/CodingWithCalvin.SuperClean.vsix
-          body: ${{ needs.changelog.outputs.changelog }}
-          makeLatest: true
-          commit: ${{ steps.artifact_manifest.outputs.sha }}
-          tag: ${{ steps.artifact_manifest.outputs.version }}
-
-      - name: 4. Publish Release to Marketplace
-        if: success()
-        uses: CodingWithCalvin/GHA-VSMarketplacePublisher@v1
-        with:
-          marketplace-pat: ${{ secrets.VS_PAT }}
-          publish-manifest-path: ./resources/extension.manifest.json
-          vsix-path: ./artifact/CodingWithCalvin.SuperClean.vsix
+    uses: CodingWithCalvin/.github/.github/workflows/vsix-publish.yml@main
+    with:
+      extension-name: SuperClean
+      display-name: 'Super Clean'
+      marketplace-id: CodingWithCalvin.VS-SuperClean
+      description: 'Clear out bin and obj folders for all projects in your solution'
+    secrets: inherit


### PR DESCRIPTION
## Summary
- Migrate build.yml to use shared vsix-build.yml workflow
- Migrate publish.yml to use shared vsix-publish.yml workflow
- Add path filters to build workflow to prevent unnecessary builds
- Includes social media notifications (BlueSky, LinkedIn) on publish