### PR TITLE
feat(telemetry): add Otel4Vsix integration

### DIFF
--- a/src/CodingWithCalvin.SuperClean/CodingWithCalvin.SuperClean.csproj
+++ b/src/CodingWithCalvin.SuperClean/CodingWithCalvin.SuperClean.csproj
@@ -8,11 +8,8 @@
     <OutputPath>bin/$(Configuration)/</OutputPath>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
-    <DeployExtension>True</DeployExtension>
-  </PropertyGroup>
-
   <ItemGroup>
+    <PackageReference Include="CodingWithCalvin.Otel4Vsix" Version="0.2.2" />
     <PackageReference Include="Community.VisualStudio.Toolkit.17" Version="17.0.492" />
     <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.14.40265" />
   </ItemGroup>

--- a/src/CodingWithCalvin.SuperClean/Commands/SuperCleanCommand.cs
+++ b/src/CodingWithCalvin.SuperClean/Commands/SuperCleanCommand.cs
@@ -81,9 +81,7 @@ namespace CodingWithCalvin.SuperClean.Commands
             }
 
             activity?.SetTag("item.type", activeItem.Type.ToString());
-            activity?.SetTag("item.name", activeItem.Name);
-
-            switch (activeItem.Type)
+                        switch (activeItem.Type)
             {
                 case SolutionItemType.Solution:
                     try
@@ -119,7 +117,7 @@ namespace CodingWithCalvin.SuperClean.Commands
                     try
                     {
                         SuperCleanProject(activeItem);
-                        VsixTelemetry.LogInformation("Project {ProjectName} super cleaned successfully", activeItem.Name);
+                        VsixTelemetry.LogInformation("Project super cleaned successfully");
                     }
                     catch (Exception ex)
                     {
@@ -127,8 +125,7 @@ namespace CodingWithCalvin.SuperClean.Commands
                         VsixTelemetry.TrackException(ex, new Dictionary<string, object>
                         {
                             { "operation.name", "SuperCleanProject" },
-                            { "project.name", activeItem.Name }
-                        });
+                            });
 
                         MessageBox.Show(
                             $@"
@@ -175,9 +172,7 @@ namespace CodingWithCalvin.SuperClean.Commands
             {
                 using var projectActivity = VsixTelemetry.StartCommandActivity("SuperClean.SuperCleanProject");
 
-                projectActivity?.SetTag("project.name", project.Name);
-
-                var projectPath =
+                                var projectPath =
                     Path.GetDirectoryName(project.FullPath)
                     ?? throw new InvalidOperationException();
 

--- a/src/CodingWithCalvin.SuperClean/HoneycombConfig.cs
+++ b/src/CodingWithCalvin.SuperClean/HoneycombConfig.cs
@@ -1,0 +1,7 @@
+namespace CodingWithCalvin.SuperClean
+{
+    internal static class HoneycombConfig
+    {
+        public const string ApiKey = "PLACEHOLDER";
+    }
+}


### PR DESCRIPTION
## Summary
- Add CodingWithCalvin.Otel4Vsix package reference (v0.2.2)
- Configure telemetry initialization in SuperCleanPackage with Honeycomb export
- Add HoneycombConfig.cs for API key placeholder (CI will replace)
- Instrument SuperClean commands with activities, logging, and exception tracking
- Track project counts and deletion status in telemetry spans
- Add proper telemetry shutdown in Dispose
- Remove explicit DeployExtension (VsixSdk handles this automatically)

## Test plan
- [ ] Verify Debug and Release builds succeed
- [ ] Verify telemetry initializes on package load
- [ ] Verify solution and project clean operations are instrumented