### PR TITLE
test(manifest): match MoreInfo URL with extension.manifest.json

### DIFF
--- a/src/CodingWithCalvin.SuperClean/source.extension.vsixmanifest
+++ b/src/CodingWithCalvin.SuperClean/source.extension.vsixmanifest
@@ -4,7 +4,7 @@
         <Identity Id="VS-SuperClean" Version="1.1" Language="en-US" Publisher="Coding With Calvin" />
         <DisplayName>Super Clean</DisplayName>
         <Description xml:space="preserve">Adds a 'Super Clean' option to the right click menu of the Solution and Project nodes of the Solution Explorer, to clear out the bin and obj folders for all, or selected, projects in the solution.</Description>
-        <MoreInfo>https://github.com/codingwithcalvin/vs-superclean</MoreInfo>
+        <MoreInfo>https://www.github.com/CodingWithCalvin/VS-SuperClean</MoreInfo>
         <License>resources\LICENSE</License>
         <Icon>resources\logo.png</Icon>
         <Tags>bin,debug,folder,output</Tags>


### PR DESCRIPTION
## Summary

- Update `<MoreInfo>` in vsixmanifest to use `www.github.com` to match `extension.manifest.json`

## Test

Testing hypothesis: marketplace link works when both URLs match, regardless of `www.` prefix.

Both files now have: `https://www.github.com/CodingWithCalvin/VS-SuperClean`