### PR TITLE
fix(manifest): remove www prefix from GitHub URLs

### DIFF
--- a/resources/extension.manifest.json
+++ b/resources/extension.manifest.json
@@ -11,5 +11,5 @@
   "overview": "../README.md",
   "publisher": "CodingWithCalvin",
   "qna": false,
-  "repo": "https://www.github.com/CodingWithCalvin/VS-SuperClean"
+  "repo": "https://github.com/CodingWithCalvin/VS-SuperClean"
 }

--- a/src/CodingWithCalvin.SuperClean/source.extension.vsixmanifest
+++ b/src/CodingWithCalvin.SuperClean/source.extension.vsixmanifest
@@ -4,7 +4,7 @@
         <Identity Id="VS-SuperClean" Version="1.1" Language="en-US" Publisher="Coding With Calvin" />
         <DisplayName>Super Clean</DisplayName>
         <Description xml:space="preserve">Adds a 'Super Clean' option to the right click menu of the Solution and Project nodes of the Solution Explorer, to clear out the bin and obj folders for all, or selected, projects in the solution.</Description>
-        <MoreInfo>https://www.github.com/CodingWithCalvin/VS-SuperClean</MoreInfo>
+        <MoreInfo>https://github.com/CodingWithCalvin/VS-SuperClean</MoreInfo>
         <License>resources\LICENSE</License>
         <Icon>resources\logo.png</Icon>
         <Tags>bin,debug,folder,output</Tags>


### PR DESCRIPTION
## Summary

- Remove `www.` prefix from GitHub URLs in both manifest files

## Files changed

- `resources/extension.manifest.json` - `repo` field
- `source.extension.vsixmanifest` - `<MoreInfo>` element

## Context

Testing confirmed that the `www.` prefix prevents the marketplace from displaying the repository link.