### PR TITLE
docs(readme): standardize format to match template

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,71 +1,98 @@
-<div align="center">
+<p align="center">
+  <img src="https://raw.githubusercontent.com/CodingWithCalvin/VS-SuperClean/main/resources/logo.png" alt="Super Clean Logo" width="128" height="128">
+</p>
 
-<img src="https://raw.githubusercontent.com/CodingWithCalvin/VS-SuperClean/main/resources/logo.png" alt="Super Clean Logo" width="256"/>
+<h1 align="center">Super Clean</h1>
+
+<p align="center">
+  <strong>Clean your solution the way it should have always worked!</strong>
+</p>
+
+<p align="center">
+  <a href="https://github.com/CodingWithCalvin/VS-SuperClean/blob/main/LICENSE">
+    <img src="https://img.shields.io/github/license/CodingWithCalvin/VS-SuperClean?style=for-the-badge" alt="License">
+  </a>
+  <a href="https://github.com/CodingWithCalvin/VS-SuperClean/actions/workflows/build.yml">
+    <img src="https://img.shields.io/github/actions/workflow/status/CodingWithCalvin/VS-SuperClean/build.yml?style=for-the-badge" alt="Build Status">
+  </a>
+</p>
+
+<p align="center">
+  <a href="https://marketplace.visualstudio.com/items?itemName=CodingWithCalvin.VS-SuperClean">
+    <img src="https://img.shields.io/visual-studio-marketplace/v/CodingWithCalvin.VS-SuperClean?style=for-the-badge" alt="Marketplace Version">
+  </a>
+  <a href="https://marketplace.visualstudio.com/items?itemName=CodingWithCalvin.VS-SuperClean">
+    <img src="https://img.shields.io/visual-studio-marketplace/i/CodingWithCalvin.VS-SuperClean?style=for-the-badge" alt="Marketplace Installations">
+  </a>
+  <a href="https://marketplace.visualstudio.com/items?itemName=CodingWithCalvin.VS-SuperClean">
+    <img src="https://img.shields.io/visual-studio-marketplace/d/CodingWithCalvin.VS-SuperClean?style=for-the-badge" alt="Marketplace Downloads">
+  </a>
+  <a href="https://marketplace.visualstudio.com/items?itemName=CodingWithCalvin.VS-SuperClean">
+    <img src="https://img.shields.io/visual-studio-marketplace/r/CodingWithCalvin.VS-SuperClean?style=for-the-badge" alt="Marketplace Rating">
+  </a>
+</p>
 
 ---
 
-[![License](https://img.shields.io/github/license/CodingWithCalvin/VS-SuperClean?style=for-the-badge)](https://github.com/CodingWithCalvin/VS-SuperClean/blob/main/LICENSE)
-[![Build](https://img.shields.io/github/actions/workflow/status/CodingWithCalvin/VS-SuperClean/build.yml?style=for-the-badge)](https://github.com/CodingWithCalvin/VS-SuperClean/actions/workflows/build.yml)
+Tired of lingering build artifacts causing mysterious issues? **Super Clean** nukes those `bin` and `obj` folders with a single click - no more hunting through folders manually!
 
-[![Visual Studio Marketplace Version](https://img.shields.io/visual-studio-marketplace/v/CodingWithCalvin.VS-SuperClean?style=for-the-badge)](https://marketplace.visualstudio.com/items?itemName=CodingWithCalvin.VS-SuperClean)
-[![Visual Studio Marketplace Installs](https://img.shields.io/visual-studio-marketplace/i/CodingWithCalvin.VS-SuperClean?style=for-the-badge)](https://marketplace.visualstudio.com/items?itemName=CodingWithCalvin.VS-SuperClean)
-[![Visual Studio Marketplace](https://img.shields.io/badge/VS%20Marketplace-Install-blue?style=for-the-badge&logo=visualstudio)](https://marketplace.visualstudio.com/items?itemName=CodingWithCalvin.VS-SuperClean)
-[![Visual Studio Marketplace Rating](https://img.shields.io/visual-studio-marketplace/r/CodingWithCalvin.VS-SuperClean?style=for-the-badge)](https://marketplace.visualstudio.com/items?itemName=CodingWithCalvin.VS-SuperClean)
-
-🧹 **Clean your solution the way it should have always worked!**
-
-Tired of lingering build artifacts causing mysterious issues? **Super Clean** nukes those `bin` and `obj` folders with a single click — no more hunting through folders manually! ✨
-
-</div>
-
-## ✨ Features
+## Features
 
 | Feature | Description |
 |---------|-------------|
-| 🗂️ **Solution-level cleaning** | Right-click the solution to clean all projects at once |
-| 📁 **Project-level cleaning** | Right-click individual projects to clean just that project |
-| 🗑️ **Removes bin folder** | Deletes the entire `bin` directory and all its contents |
-| 📦 **Removes obj folder** | Deletes the entire `obj` directory and all its contents |
-| ⚡ **Fast and reliable** | Quick deletion without the overhead of MSBuild's Clean target |
+| **Solution-level cleaning** | Right-click the solution to clean all projects at once |
+| **Project-level cleaning** | Right-click individual projects to clean just that project |
+| **Removes bin folder** | Deletes the entire `bin` directory and all its contents |
+| **Removes obj folder** | Deletes the entire `obj` directory and all its contents |
+| **Fast and reliable** | Quick deletion without the overhead of MSBuild's Clean target |
 
-## 📥 Installation
+## Installation
 
-### Visual Studio Marketplace (Recommended)
+### Visual Studio Marketplace
 
-[![Install from VS Marketplace](https://img.shields.io/badge/Install%20from-VS%20Marketplace-purple?style=for-the-badge&logo=visualstudio)](https://marketplace.visualstudio.com/items?itemName=CodingWithCalvin.VS-SuperClean)
+1. Open Visual Studio 2022 or 2026
+2. Go to **Extensions > Manage Extensions**
+3. Search for "Super Clean"
+4. Click **Download** and restart Visual Studio
 
 ### Manual Installation
 
-1. 📥 Download the `.vsix` file from the [Releases](https://github.com/CodingWithCalvin/VS-SuperClean/releases) page
-2. 🖱️ Double-click the downloaded file to install
+Download the latest `.vsix` from the [Releases](https://github.com/CodingWithCalvin/VS-SuperClean/releases) page and double-click to install.
 
-## 🎮 Usage
+## Usage
 
-1. 🖱️ Right-click on a **Solution** or **Project** in Solution Explorer
-2. 📋 Select **Super Clean**
-3. 🧹 Watch those `bin` and `obj` folders disappear!
+1. Right-click on a **Solution** or **Project** in Solution Explorer
+2. Select **Super Clean**
+3. Watch those `bin` and `obj` folders disappear!
 
-## 💻 Supported Versions
+## Supported Versions
 
 | Visual Studio | Architectures |
 |---------------|---------------|
-| 🟢 Visual Studio 2022 (17.x) | x64 (amd64), ARM64 |
-| 🟢 Visual Studio 2026 (18.x) | x64 (amd64), ARM64 |
+| Visual Studio 2022 (17.x) | x64 (amd64), ARM64 |
+| Visual Studio 2026 (18.x) | x64 (amd64), ARM64 |
 
-## 📄 License
+## Contributing
 
-This project is licensed under the [MIT License](LICENSE).
+Contributions are welcome! Whether it's bug reports, feature requests, or pull requests - all feedback helps make this extension better.
 
-## 🤝 Contributing
+### Development Setup
 
-Contributions are welcome! Issues, PRs, feature requests — bring it on! 💪
+1. Clone the repository
+2. Open the solution in Visual Studio 2022 or 2026
+3. Ensure you have the "Visual Studio extension development" workload installed
+4. Install the [Extensibility Essentials 2022](https://marketplace.visualstudio.com/items?itemName=MadsKristensen.ExtensibilityEssentials2022) extension
+5. Press F5 to launch the experimental instance
 
-For cloning and building this project yourself, make sure to install the [Extensibility Essentials 2022 extension](https://marketplace.visualstudio.com/items?itemName=MadsKristensen.ExtensibilityEssentials2022) for Visual Studio which enables some features used by this project.
+## License
 
-## 👥 Contributors
+This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+
+---
+
+## Contributors
 
 <!-- readme: contributors -start -->
-[![CalvinAllen](https://avatars.githubusercontent.com/u/41448698?v=4&s=64)](https://github.com/CalvinAllen)
 <!-- readme: contributors -end -->
 
 ---


### PR DESCRIPTION
## Summary
- Standardized README to match the extension template format
- Centered header with logo (128x128), h1 title, and tagline
- Two rows of badges: License/Build first, then Marketplace badges
- Consistent section structure with horizontal rules
- Contributors section with markers for auto-population
- Centered footer with attribution
- Removed div wrapper, using separate p align=center elements