### PR TITLE
fix(commands): skip Web Site projects when cleaning

### DIFF
--- a/src/CodingWithCalvin.SuperClean/Commands/SuperCleanCommand.cs
+++ b/src/CodingWithCalvin.SuperClean/Commands/SuperCleanCommand.cs
@@ -86,7 +86,7 @@ namespace CodingWithCalvin.SuperClean.Commands
                 case SolutionItemType.Solution:
                     try
                     {
-                        var (success, errors) = await SuperCleanSolution();
+                        var (success, errors, skippedWebsites) = await SuperCleanSolution();
 
                         if (!success)
                         {
@@ -94,6 +94,16 @@ namespace CodingWithCalvin.SuperClean.Commands
                         }
 
                         VsixTelemetry.LogInformation("Solution super cleaned successfully");
+
+                        if (skippedWebsites.Count > 0)
+                        {
+                            MessageBox.Show(
+                                $"Super Clean skipped the following Web Site project(s) because their bin folder is required at runtime:{Environment.NewLine}{Environment.NewLine}  • {string.Join($"{Environment.NewLine}  • ", skippedWebsites)}",
+                                "Super Clean",
+                                System.Windows.Forms.MessageBoxButtons.OK,
+                                System.Windows.Forms.MessageBoxIcon.Information
+                            );
+                        }
                     }
                     catch (Exception ex)
                     {
@@ -117,9 +127,22 @@ namespace CodingWithCalvin.SuperClean.Commands
                     try
                     {
                         var cleaned = await SuperCleanProjectAsync(activeItem);
-                        VsixTelemetry.LogInformation(cleaned
-                            ? "Project super cleaned successfully"
-                            : $"Project skipped: {activeItem.Name}");
+
+                        if (cleaned)
+                        {
+                            VsixTelemetry.LogInformation("Project super cleaned successfully");
+                        }
+                        else
+                        {
+                            VsixTelemetry.LogInformation($"Project skipped: {activeItem.Name}");
+
+                            MessageBox.Show(
+                                $"Super Clean skipped \"{activeItem.Name}\" because Web Site projects rely on their bin folder at runtime.",
+                                "Super Clean",
+                                System.Windows.Forms.MessageBoxButtons.OK,
+                                System.Windows.Forms.MessageBoxIcon.Information
+                            );
+                        }
                     }
                     catch (Exception ex)
                     {
@@ -141,13 +164,14 @@ namespace CodingWithCalvin.SuperClean.Commands
                     break;
             }
 
-            async Task<(bool, string)> SuperCleanSolution()
+            async Task<(bool, string, List<string>)> SuperCleanSolution()
             {
                 using var solutionActivity = VsixTelemetry.StartCommandActivity("SuperClean.SuperCleanSolution");
 
                 var success = true;
                 var errors = new StringBuilder();
                 var projectCount = 0;
+                var skippedWebsites = new List<string>();
 
                 foreach (var project in await VS.Solutions.GetAllProjectsAsync())
                 {
@@ -156,6 +180,10 @@ namespace CodingWithCalvin.SuperClean.Commands
                         if (await SuperCleanProjectAsync(project))
                         {
                             projectCount++;
+                        }
+                        else
+                        {
+                            skippedWebsites.Add(project.Name);
                         }
                     }
                     catch (Exception ex)
@@ -167,9 +195,10 @@ namespace CodingWithCalvin.SuperClean.Commands
                 }
 
                 solutionActivity?.SetTag("projects.cleaned", projectCount);
+                solutionActivity?.SetTag("projects.skipped", skippedWebsites.Count);
                 solutionActivity?.SetTag("success", success);
 
-                return (success, errors.ToString());
+                return (success, errors.ToString(), skippedWebsites);
             }
 
             async Task<bool> SuperCleanProjectAsync(SolutionItem project)

--- a/src/CodingWithCalvin.SuperClean/Commands/SuperCleanCommand.cs
+++ b/src/CodingWithCalvin.SuperClean/Commands/SuperCleanCommand.cs
@@ -116,8 +116,10 @@ namespace CodingWithCalvin.SuperClean.Commands
                 case SolutionItemType.Project:
                     try
                     {
-                        SuperCleanProject(activeItem);
-                        VsixTelemetry.LogInformation("Project super cleaned successfully");
+                        var cleaned = await SuperCleanProjectAsync(activeItem);
+                        VsixTelemetry.LogInformation(cleaned
+                            ? "Project super cleaned successfully"
+                            : $"Project skipped: {activeItem.Name}");
                     }
                     catch (Exception ex)
                     {
@@ -151,8 +153,10 @@ namespace CodingWithCalvin.SuperClean.Commands
                 {
                     try
                     {
-                        SuperCleanProject(project);
-                        projectCount++;
+                        if (await SuperCleanProjectAsync(project))
+                        {
+                            projectCount++;
+                        }
                     }
                     catch (Exception ex)
                     {
@@ -168,11 +172,19 @@ namespace CodingWithCalvin.SuperClean.Commands
                 return (success, errors.ToString());
             }
 
-            void SuperCleanProject(SolutionItem project)
+            async Task<bool> SuperCleanProjectAsync(SolutionItem project)
             {
                 using var projectActivity = VsixTelemetry.StartCommandActivity("SuperClean.SuperCleanProject");
 
-                                var projectPath =
+                if (project is Project typedProject && await typedProject.IsKindAsync(ProjectTypes.WEBSITE))
+                {
+                    projectActivity?.SetTag("skipped", true);
+                    projectActivity?.SetTag("skip.reason", "website-project");
+                    VsixTelemetry.LogInformation($"Skipped Web Site project: {project.Name}");
+                    return false;
+                }
+
+                var projectPath =
                     Path.GetDirectoryName(project.FullPath)
                     ?? throw new InvalidOperationException();
 
@@ -190,6 +202,8 @@ namespace CodingWithCalvin.SuperClean.Commands
                     Directory.Delete(objPath, true);
                     projectActivity?.SetTag("obj.deleted", true);
                 }
+
+                return true;
             }
         }
     }


### PR DESCRIPTION
## Summary

- Detect legacy Web Site Projects (project type GUID `{E24C65DC-7377-472B-9ABA-BC803B73C61A}`) via `Project.IsKindAsync(ProjectTypes.WEBSITE)` and skip them — their `bin` folder holds integral runtime assemblies, not build output.
- When invoked on the solution, other projects clean as before and a single summary MessageBox lists any skipped Web Site projects.
- When invoked directly on a Web Site project node, Super Clean no-ops on disk and shows a MessageBox naming the skipped project so the user knows why nothing happened.

## Test plan

- [ ] Open a solution containing a Web Site Project + at least one SDK project; right-click solution → **Super Clean**. Verify SDK project's `bin`/`obj` are cleared, the website's `bin` is untouched, and a summary MessageBox lists the website by name.
- [ ] Right-click the Web Site Project node directly → **Super Clean**. Verify `bin` is untouched and a MessageBox names the skipped project.
- [ ] Right-click an SDK project node → **Super Clean**. Verify it still cleans as before and no MessageBox is shown (regression check).
- [ ] Solution with multiple Web Site projects + SDK projects → **Super Clean** on solution. Verify the summary MessageBox lists every skipped website.

Resolves #31