### PR TITLE
fix(commands): refresh Solution Explorer after cleaning bin/obj

### DIFF
--- a/src/CodingWithCalvin.SuperClean/Commands/SuperCleanCommand.cs
+++ b/src/CodingWithCalvin.SuperClean/Commands/SuperCleanCommand.cs
@@ -6,7 +6,9 @@ using System.Text;
 using System.Threading.Tasks;
 using CodingWithCalvin.Otel4Vsix;
 using Community.VisualStudio.Toolkit;
+using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
 using MessageBox = System.Windows.Forms.MessageBox;
 
 namespace CodingWithCalvin.SuperClean.Commands
@@ -232,8 +234,33 @@ namespace CodingWithCalvin.SuperClean.Commands
                     projectActivity?.SetTag("obj.deleted", true);
                 }
 
+                await RefreshInSolutionExplorerAsync(project);
+
                 return true;
             }
+        }
+
+        private static async Task RefreshInSolutionExplorerAsync(SolutionItem project)
+        {
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+            project.GetItemInfo(out IVsHierarchy hierarchy, out uint itemId, out _);
+
+            if (hierarchy is not IVsUIHierarchy uiHierarchy)
+            {
+                return;
+            }
+
+            var cmdGuid = VSConstants.GUID_VSStandardCommandSet97;
+
+            uiHierarchy.ExecCommand(
+                itemId,
+                ref cmdGuid,
+                (uint)VSConstants.VSStd97CmdID.Refresh,
+                0,
+                IntPtr.Zero,
+                IntPtr.Zero
+            );
         }
     }
 }


### PR DESCRIPTION
## Summary
- Sends the standard `VSStd97CmdID.Refresh` command to each cleaned project's `IVsUIHierarchy` after deleting bin/obj.
- Same code path as right-click → Refresh, so stale "Show All Files" nodes disappear without an unload/reload.
- No Solution Explorer selection change, no visible collapse/expand flash.

## Test plan
- [ ] Open a solution with `Show All Files` enabled on a project that has built bin/obj content.
- [ ] Run Super Clean on the solution — verify the bin/obj nodes disappear from Solution Explorer immediately (no unload/reload needed).
- [ ] Run Super Clean on a single project — verify the same.
- [ ] Verify Web Site projects are still skipped with the existing notification.
- [ ] Verify the active Solution Explorer selection is unchanged after Super Clean completes.

Resolves #33